### PR TITLE
Deliverable3

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,27 @@ In the second deliverable I have:
    - Created a router group to have API versioning. Currently the `/v1` is supported.
    - Moved configuration logic to its own package in [`config`](/config).
 
+## Final deliverable
+
+In the final deliverable I have:
+
+1. Implemented a `/pokemons/type/{parity}/items/{items}/items_per_worker/{items_per_worker}` endpoint that returns a JSON array of pokemons filtered by the parity (even or odd) of their ID. This endpoint uses the _worker pool pattern_ to filter the pokemons.
+
+   The `{items}` parameter specifies how many pokemons must at least appear in the array, although if `{items}` is greater than the amount of total even or odd pokemons, all filtered pokemons will be returned.
+
+   The `{items_per_worker}` parameter specifies at most how many pokemons each worker will process.
+
+   The amount of workers that are spawned is computed with the following formula:
+
+   ```
+   #workers = ceil(items / items_per_worker)
+   ```
+
+   The endpoint is also limited to spawn up to 20 workers. If the amount of workers computed is greater than 20, then the endpoint will return a 400 HTTP error suggesting that the client should decrease the amount of `{items}` or increase the amount of `{items_per_worker}`.
+
+2. Wrote documentation for the new logic.
+3. Created test cases for the new logic.
+
 ---
 
 Everything below this line is the original README.

--- a/adapter/pokemon_adapter.go
+++ b/adapter/pokemon_adapter.go
@@ -3,13 +3,21 @@ package adapter
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/nibble-4bits/ondemand-go-bootcamp/entity"
 )
 
+const (
+	// Max number of goroutines that can be spawned by a worker pool
+	MAX_WORKERS = 20
+)
+
 var (
-	ErrPokemonsNotFound    = errors.New("no pokemons found")
-	ErrPokemonNotFoundByID = errors.New("no pokemon found by ID")
+	ErrPokemonsNotFound      = errors.New("no pokemons found")
+	ErrPokemonNotFoundByID   = errors.New("no pokemon found by ID")
+	ErrUnsupportedParityType = errors.New("unsupported parity type. Must be one of 'even' or 'odd'")
+	ErrMaxNumberOfWorkers    = errors.New("max number of workers excedeed")
 )
 
 type pokemonAdapter struct {
@@ -84,4 +92,79 @@ func (a *pokemonAdapter) GetAll() ([]entity.Pokemon, error) {
 	}
 
 	return a.pokemons, nil
+}
+
+// GetByParity returns an slice of pokemons filtered by "even" or "odd" parity,
+// using the worker pool pattern.
+//
+// The following arguments have to be passed:
+//
+// - parity: Must be "even" or "odd".
+//
+// - workers: The number of goroutines to spawn.
+//
+// - itemCount: The number of pokemons that must appear in the resulting slice.
+//
+// - quota: The number of pokemons each goroutine will process at most to verify if they match
+// the corresponding parity.
+func (a *pokemonAdapter) GetByParity(parity string, workers int, itemCount int, quota int) ([]entity.Pokemon, error) {
+	if parity != "even" && parity != "odd" {
+		return nil, ErrUnsupportedParityType
+	}
+	if workers > MAX_WORKERS {
+		return nil, fmt.Errorf("%w. Consider incrementing the items per worker or decreasing the number of items to filter", ErrMaxNumberOfWorkers)
+	}
+
+	workerFunc := func(parity string, quota int, jobs <-chan entity.Pokemon, results chan<- entity.Pokemon) {
+		found := 0
+
+		for p := range jobs {
+			if (parity == "even" && p.ID%2 == 0) || (parity == "odd" && p.ID%2 == 1) {
+				found++
+				results <- p
+			}
+
+			if found == quota {
+				return
+			}
+		}
+
+	}
+
+	pokemons, err := a.GetAll()
+	if err != nil {
+		return nil, fmt.Errorf("%w", err)
+	}
+
+	jobs := make(chan entity.Pokemon, len(pokemons))
+	results := make(chan entity.Pokemon, (len(pokemons)/2)+1)
+	wg := sync.WaitGroup{}
+	remainingItems := itemCount
+	for i := 0; i < workers; i++ {
+		actualQuota := quota
+		if remainingItems < quota {
+			actualQuota = remainingItems
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			workerFunc(parity, actualQuota, jobs, results)
+		}()
+		remainingItems -= quota
+	}
+
+	for _, pokemon := range pokemons {
+		jobs <- pokemon
+	}
+	close(jobs)
+
+	wg.Wait()
+	close(results)
+
+	var filteredPokemons []entity.Pokemon
+	for result := range results {
+		filteredPokemons = append(filteredPokemons, result)
+	}
+
+	return filteredPokemons, nil
 }

--- a/adapter/pokemon_adapter.go
+++ b/adapter/pokemon_adapter.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 
 	"github.com/nibble-4bits/ondemand-go-bootcamp/entity"
@@ -101,16 +102,19 @@ func (a *pokemonAdapter) GetAll() ([]entity.Pokemon, error) {
 //
 // - parity: Must be "even" or "odd".
 //
-// - workers: The number of goroutines to spawn.
-//
 // - itemCount: The number of pokemons that must appear in the resulting slice.
 //
 // - quota: The number of pokemons each goroutine will process at most to verify if they match
 // the corresponding parity.
-func (a *pokemonAdapter) GetByParity(parity string, workers int, itemCount int, quota int) ([]entity.Pokemon, error) {
+func (a *pokemonAdapter) GetByParity(parity string, itemCount int, quota int) ([]entity.Pokemon, error) {
 	if parity != "even" && parity != "odd" {
 		return nil, ErrUnsupportedParityType
 	}
+
+	// The number of workers is calculated as the itemCount divided by the quota (items per worker)
+	// We use the math.Ceil function to ensure the number of workers is at least 1
+	// in case itemCount < quota
+	workers := int(math.Ceil(float64(itemCount) / float64(quota)))
 	if workers > MAX_WORKERS {
 		return nil, fmt.Errorf("%w. Consider incrementing the items per worker or decreasing the number of items to filter", ErrMaxNumberOfWorkers)
 	}

--- a/httpAPI/v1/controller/pokemon_controller.go
+++ b/httpAPI/v1/controller/pokemon_controller.go
@@ -102,10 +102,10 @@ func GetEvenOrOddPokemons(service usecase.PokemonService) gin.HandlerFunc {
 			case errors.Is(err, adapter.ErrPokemonsNotFound):
 				c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 				return
-			case errors.Is(err, usecase.ErrUnsupportedParityType):
+			case errors.Is(err, adapter.ErrUnsupportedParityType):
 				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 				return
-			case errors.Is(err, usecase.ErrMaxNumberOfWorkers):
+			case errors.Is(err, adapter.ErrMaxNumberOfWorkers):
 				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 				return
 			default:

--- a/httpAPI/v1/controller/pokemon_controller.go
+++ b/httpAPI/v1/controller/pokemon_controller.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"errors"
-	"math"
 	"net/http"
 	"strconv"
 
@@ -92,11 +91,7 @@ func GetEvenOrOddPokemons(service usecase.PokemonService) gin.HandlerFunc {
 			return
 		}
 
-		// The number of workers is calculated as the itemCount divided by the items per worker
-		// We use the math.Ceil function to ensure the number of workers is at least 1
-		// in case itemCount < itemsPerWorker
-		workers := math.Ceil(float64(itemCount) / float64(itemsPerWorker))
-		pokemons, err := service.GetByParity(parity, int(workers), itemCount, itemsPerWorker)
+		pokemons, err := service.GetByParity(parity, itemCount, itemsPerWorker)
 		if err != nil {
 			switch {
 			case errors.Is(err, adapter.ErrPokemonsNotFound):

--- a/httpAPI/v1/controller/pokemon_controller.go
+++ b/httpAPI/v1/controller/pokemon_controller.go
@@ -61,6 +61,19 @@ func GetAllPokemons(service usecase.PokemonService) gin.HandlerFunc {
 	}
 }
 
+// GetEvenOrOddPokemons handles the logic of getting an slice of even or odd pokemons, depending on the
+// `:parity` path parameter.
+//
+// The number of pokemons to be added to the response is defined by the `:items` parameter.
+// The resulting array is guaranteed to contain the exact number of items, unless the `:items` param
+// is greater than the total amount of even or odd pokemons, in which case the response will contain
+// the entire list of filtered pokemons.
+//
+// The number of items processed by each goroutine is defined by the `:items_per_worker` parameter.
+// For example, if you pass 8 as `:items_per_worker`, each goroutine will process at most 8 pokemons
+// to verify if each one passes the parity filter.
+//
+// If an error occurs, it will send that instead.
 func GetEvenOrOddPokemons(service usecase.PokemonService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		parity := c.Param("parity")
@@ -79,6 +92,9 @@ func GetEvenOrOddPokemons(service usecase.PokemonService) gin.HandlerFunc {
 			return
 		}
 
+		// The number of workers is calculated as the itemCount divided by the items per worker
+		// We use the math.Ceil function to ensure the number of workers is at least 1
+		// in case itemCount < itemsPerWorker
 		workers := math.Ceil(float64(itemCount) / float64(itemsPerWorker))
 		pokemons, err := service.GetByParity(parity, int(workers), itemCount, itemsPerWorker)
 		if err != nil {

--- a/httpAPI/v1/controller/pokemon_controller.go
+++ b/httpAPI/v1/controller/pokemon_controller.go
@@ -105,6 +105,9 @@ func GetEvenOrOddPokemons(service usecase.PokemonService) gin.HandlerFunc {
 			case errors.Is(err, usecase.ErrUnsupportedParityType):
 				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 				return
+			case errors.Is(err, usecase.ErrMaxNumberOfWorkers):
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
 			default:
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			}

--- a/httpAPI/v1/controller/pokemon_controller.go
+++ b/httpAPI/v1/controller/pokemon_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"errors"
+	"math"
 	"net/http"
 	"strconv"
 
@@ -49,6 +50,43 @@ func GetAllPokemons(service usecase.PokemonService) gin.HandlerFunc {
 		if err != nil {
 			switch {
 			case errors.Is(err, adapter.ErrPokemonsNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+				return
+			default:
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			}
+		}
+
+		c.JSON(http.StatusOK, pokemons)
+	}
+}
+
+func GetEvenOrOddPokemons(service usecase.PokemonService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		parity := c.Param("parity")
+		itemCountStr := c.Param("items")
+		itemsPerWorkerStr := c.Param("items_per_worker")
+
+		itemCount, err := strconv.Atoi(itemCountStr)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		itemsPerWorker, err := strconv.Atoi(itemsPerWorkerStr)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		workers := math.Ceil(float64(itemCount) / float64(itemsPerWorker))
+		pokemons, err := service.GetByParity(parity, int(workers), itemCount, itemsPerWorker)
+		if err != nil {
+			switch {
+			case errors.Is(err, adapter.ErrPokemonsNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+				return
+			case errors.Is(err, usecase.ErrUnsupportedParityType):
 				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 				return
 			default:

--- a/httpAPI/v1/router/pokemon_routes.go
+++ b/httpAPI/v1/router/pokemon_routes.go
@@ -15,7 +15,12 @@ func getAllPokemons(r *gin.RouterGroup, service usecase.PokemonService) {
 	r.GET("/pokemons", controller.GetAllPokemons(service))
 }
 
+func getPokemonsByEvenOrOddID(r *gin.RouterGroup, service usecase.PokemonService) {
+	r.GET("/pokemons/type/:parity/items/:items/items_per_worker/:items_per_worker", controller.GetEvenOrOddPokemons(service))
+}
+
 func RegisterPokemonRoutes(r *gin.RouterGroup, service usecase.PokemonService) {
 	getPokemonByID(r, service)
 	getAllPokemons(r, service)
+	getPokemonsByEvenOrOddID(r, service)
 }

--- a/usecase/pokemon_repository.go
+++ b/usecase/pokemon_repository.go
@@ -7,5 +7,5 @@ import "github.com/nibble-4bits/ondemand-go-bootcamp/entity"
 type PokemonRepository interface {
 	GetByID(id int) (*entity.Pokemon, error)
 	GetAll() ([]entity.Pokemon, error)
-	GetByParity(parity string, workers int, itemCount int, quota int) ([]entity.Pokemon, error)
+	GetByParity(parity string, itemCount int, quota int) ([]entity.Pokemon, error)
 }

--- a/usecase/pokemon_repository.go
+++ b/usecase/pokemon_repository.go
@@ -7,4 +7,5 @@ import "github.com/nibble-4bits/ondemand-go-bootcamp/entity"
 type PokemonRepository interface {
 	GetByID(id int) (*entity.Pokemon, error)
 	GetAll() ([]entity.Pokemon, error)
+	GetByParity(parity string, workers int, itemCount int, quota int) ([]entity.Pokemon, error)
 }

--- a/usecase/pokemon_service.go
+++ b/usecase/pokemon_service.go
@@ -8,8 +8,14 @@ import (
 	"github.com/nibble-4bits/ondemand-go-bootcamp/entity"
 )
 
+const (
+	// Max number of goroutines that can be spawned by a worker pool
+	MAX_WORKERS = 20
+)
+
 var (
 	ErrUnsupportedParityType = errors.New("unsupported parity type. Must be one of 'even' or 'odd'")
+	ErrMaxNumberOfWorkers    = errors.New("max number of workers excedeed")
 )
 
 type pokemonService struct {
@@ -65,6 +71,9 @@ func (s pokemonService) GetAll() ([]entity.Pokemon, error) {
 func (s pokemonService) GetByParity(parity string, workers int, itemCount int, quota int) ([]entity.Pokemon, error) {
 	if parity != "even" && parity != "odd" {
 		return nil, ErrUnsupportedParityType
+	}
+	if workers > MAX_WORKERS {
+		return nil, fmt.Errorf("%w. Consider incrementing the items per worker or decreasing the number of items to filter", ErrMaxNumberOfWorkers)
 	}
 
 	workerFunc := func(parity string, quota int, jobs <-chan entity.Pokemon, results chan<- entity.Pokemon) {

--- a/usecase/pokemon_service.go
+++ b/usecase/pokemon_service.go
@@ -15,7 +15,7 @@ type pokemonService struct {
 type PokemonService interface {
 	GetByID(id int) (*entity.Pokemon, error)
 	GetAll() ([]entity.Pokemon, error)
-	GetByParity(parity string, workers int, itemCount int, quota int) ([]entity.Pokemon, error)
+	GetByParity(parity string, itemCount int, quota int) ([]entity.Pokemon, error)
 }
 
 // NewPokemonService receives a PokemonRepository and returns an instance of pokemonService
@@ -44,8 +44,8 @@ func (s pokemonService) GetAll() ([]entity.Pokemon, error) {
 }
 
 // GetByParity returns an slice of pokemons filtered by "even" or "odd" parity.
-func (s pokemonService) GetByParity(parity string, workers int, itemCount int, quota int) ([]entity.Pokemon, error) {
-	pokemons, err := s.repo.GetByParity(parity, workers, itemCount, quota)
+func (s pokemonService) GetByParity(parity string, itemCount int, quota int) ([]entity.Pokemon, error) {
+	pokemons, err := s.repo.GetByParity(parity, itemCount, quota)
 	if err != nil {
 		return nil, fmt.Errorf("%w", err)
 	}

--- a/usecase/pokemon_service.go
+++ b/usecase/pokemon_service.go
@@ -53,7 +53,7 @@ func (s pokemonService) GetByParity(parity string, workers int, itemCount int, q
 		return nil, ErrUnsupportedParityType
 	}
 
-	workerFunc := func(id int, parity string, quota int, jobs <-chan entity.Pokemon, results chan<- entity.Pokemon) {
+	workerFunc := func(parity string, quota int, jobs <-chan entity.Pokemon, results chan<- entity.Pokemon) {
 		found := 0
 
 		for p := range jobs {
@@ -82,7 +82,7 @@ func (s pokemonService) GetByParity(parity string, workers int, itemCount int, q
 		if remainingItems < quota {
 			actualQuota = remainingItems
 		}
-		go workerFunc(i+1, parity, actualQuota, jobs, results)
+		go workerFunc(parity, actualQuota, jobs, results)
 		remainingItems -= quota
 	}
 

--- a/usecase/pokemon_service.go
+++ b/usecase/pokemon_service.go
@@ -1,9 +1,14 @@
 package usecase
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/nibble-4bits/ondemand-go-bootcamp/entity"
+)
+
+var (
+	ErrUnsupportedParityType = errors.New("unsupported parity type. Must be one of 'even' or 'odd'")
 )
 
 type pokemonService struct {
@@ -15,6 +20,7 @@ type pokemonService struct {
 type PokemonService interface {
 	GetByID(id int) (*entity.Pokemon, error)
 	GetAll() ([]entity.Pokemon, error)
+	GetByParity(parity string, workers int, itemCount int, quota int) ([]entity.Pokemon, error)
 }
 
 // NewPokemonService receives a PokemonRepository and returns an instance of pokemonService
@@ -40,4 +46,61 @@ func (s pokemonService) GetAll() ([]entity.Pokemon, error) {
 	}
 
 	return pokemons, nil
+}
+
+func (s pokemonService) GetByParity(parity string, workers int, itemCount int, quota int) ([]entity.Pokemon, error) {
+	if parity != "even" && parity != "odd" {
+		return nil, ErrUnsupportedParityType
+	}
+
+	workerFunc := func(id int, parity string, quota int, jobs <-chan entity.Pokemon, results chan<- entity.Pokemon) {
+		found := 0
+
+		for p := range jobs {
+			if (parity == "even" && p.ID%2 == 0) || (parity == "odd" && p.ID%2 == 1) {
+				found++
+				results <- p
+			}
+
+			if found == quota {
+				return
+			}
+		}
+
+	}
+
+	pokemons, err := s.repo.GetAll()
+	if err != nil {
+		return nil, fmt.Errorf("%w", err)
+	}
+
+	jobs := make(chan entity.Pokemon, len(pokemons))
+	results := make(chan entity.Pokemon, (len(pokemons)/2)+1)
+	remainingItems := itemCount
+	for i := 0; i < workers; i++ {
+		actualQuota := quota
+		if remainingItems < quota {
+			actualQuota = remainingItems
+		}
+		go workerFunc(i+1, parity, actualQuota, jobs, results)
+		remainingItems -= quota
+	}
+
+	for _, pokemon := range pokemons {
+		jobs <- pokemon
+	}
+	close(jobs)
+
+	var filteredPokemons []entity.Pokemon
+	var resultsEnd int
+	if itemCount <= (len(pokemons)/2)+1 {
+		resultsEnd = itemCount
+	} else {
+		resultsEnd = (len(pokemons) / 2) + 1
+	}
+	for i := 0; i < resultsEnd; i++ {
+		filteredPokemons = append(filteredPokemons, <-results)
+	}
+
+	return filteredPokemons, nil
 }

--- a/usecase/pokemon_service.go
+++ b/usecase/pokemon_service.go
@@ -48,6 +48,19 @@ func (s pokemonService) GetAll() ([]entity.Pokemon, error) {
 	return pokemons, nil
 }
 
+// GetByParity returns an slice of pokemons filtered by "even" or "odd" parity,
+// using the worker pool pattern.
+//
+// The following arguments have to be passed:
+//
+// - parity: Must be "even" or "odd".
+//
+// - workers: The number of goroutines to spawn.
+//
+// - itemCount: The number of pokemons that must appear in the resulting slice.
+//
+// - quota: The number of pokemons each goroutine will process at most to verify if they match
+// the corresponding parity.
 func (s pokemonService) GetByParity(parity string, workers int, itemCount int, quota int) ([]entity.Pokemon, error) {
 	if parity != "even" && parity != "odd" {
 		return nil, ErrUnsupportedParityType


### PR DESCRIPTION
In the final deliverable I have:

1. Implemented a `/pokemons/type/{parity}/items/{items}/items_per_worker/{items_per_worker}` endpoint that returns a JSON array of pokemons filtered by the parity (even or odd) of their ID. This endpoint uses the _worker pool pattern_ to filter the pokemons.

   The `{items}` parameter specifies how many pokemons must at least appear in the array, although if `{items}` is greater than the amount of total even or odd pokemons, all filtered pokemons will be returned.

   The `{items_per_worker}` parameter specifies at most how many pokemons each worker will process.

   The amount of workers that are spawned is computed with the following formula:

   ```
   #workers = ceil(items / items_per_worker)
   ```

   The endpoint is also limited to spawn up to 20 workers. If the amount of workers computed is greater than 20, then the endpoint will return a 400 HTTP error suggesting that the client should decrease the amount of `{items}` or increase the amount of `{items_per_worker}`.

2. Wrote documentation for the new logic.
3. Created test cases for the new logic.

---

NOTE: I've set the base branch of this PR to `deliverable2` so that only the files changes since the `deliverable2` branch are shown.